### PR TITLE
chore: event hub cluster scraper

### DIFF
--- a/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
+++ b/src/Promitor.Agents.Scraper/Validation/Factories/MetricValidatorFactory.cs
@@ -45,6 +45,8 @@ namespace Promitor.Agents.Scraper.Validation.Factories
                     return new DeviceProvisioningServiceMetricValidator();
                 case ResourceType.EventHubs:
                     return new EventHubsMetricValidator();
+                case ResourceType.EventHubCluster:
+                    return new EventHubClusterMetricValidator();
                 case ResourceType.ExpressRouteCircuit:
                     return new ExpressRouteCircuitMetricsValidator();
                 case ResourceType.FileStorage:

--- a/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/EventHubClusterMetricValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/EventHubClusterMetricValidator.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+using GuardNet;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Agents.Scraper.Validation.MetricDefinitions.Interfaces;
+using Promitor.Core.Contracts.ResourceTypes;
+
+namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
+{
+    internal class EventHubClusterMetricValidator : IMetricValidator
+    {
+        public IEnumerable<string> Validate(MetricDefinition metricDefinition)
+        {
+            Guard.NotNull(metricDefinition, nameof(metricDefinition));
+
+            var errorMessages = new List<string>();
+
+            foreach (var resourceDefinition in metricDefinition.Resources.Cast<EventHubClusterResourceDefinition>())
+            {
+                if (string.IsNullOrWhiteSpace(resourceDefinition.ClusterName))
+                {
+                    errorMessages.Add("No Azure Event Hub ClusterName is configured");
+                }
+            }
+
+            return errorMessages;
+        }
+    }
+}

--- a/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/EventHubClusterMetricValidator.cs
+++ b/src/Promitor.Agents.Scraper/Validation/MetricDefinitions/ResourceTypes/EventHubClusterMetricValidator.cs
@@ -12,10 +12,11 @@ namespace Promitor.Agents.Scraper.Validation.MetricDefinitions.ResourceTypes
         public IEnumerable<string> Validate(MetricDefinition metricDefinition)
         {
             Guard.NotNull(metricDefinition, nameof(metricDefinition));
+            var eventHubClusterResources = metricDefinition.Resources.OfType<EventHubClusterResourceDefinition>().ToList();
 
             var errorMessages = new List<string>();
 
-            foreach (var resourceDefinition in metricDefinition.Resources.Cast<EventHubClusterResourceDefinition>())
+            foreach (var resourceDefinition in eventHubClusterResources)
             {
                 if (string.IsNullOrWhiteSpace(resourceDefinition.ClusterName))
                 {

--- a/src/Promitor.Core.Contracts/ResourceType.cs
+++ b/src/Promitor.Core.Contracts/ResourceType.cs
@@ -57,5 +57,6 @@
         PowerBiDedicated = 52,
         AzureFirewall = 53,
         CognitiveServicesAccount = 54,
+        EventHubCluster = 55,
     }
 }

--- a/src/Promitor.Core.Contracts/ResourceTypes/EventHubClusterResourceDefinition.cs
+++ b/src/Promitor.Core.Contracts/ResourceTypes/EventHubClusterResourceDefinition.cs
@@ -1,0 +1,15 @@
+using Promitor.Core.Contracts;
+
+namespace Promitor.Core.Contracts.ResourceTypes
+{
+    public class EventHubClusterResourceDefinition : AzureResourceDefinition
+    {
+        public EventHubClusterResourceDefinition(string subscriptionId, string resourceGroupName, string clusterName)
+            : base(ResourceType.EventHubCluster, subscriptionId, resourceGroupName, clusterName)
+        {
+            ClusterName = clusterName;
+        }
+
+        public string ClusterName { get; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Core/AzureResourceDeserializerFactory.cs
@@ -72,6 +72,9 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Core
                 case ResourceType.EventHubs:
                     var eventHubsLogger = _loggerFactory.CreateLogger<EventHubsDeserializer>();
                     return new EventHubsDeserializer(eventHubsLogger);
+                case ResourceType.EventHubCluster:
+                    var eventHubClusterLogger = _loggerFactory.CreateLogger<EventHubClusterDeserializer>();
+                    return new EventHubClusterDeserializer(eventHubClusterLogger);
                 case ResourceType.ExpressRouteCircuit:
                     var expressRouteCircuitLogger = _loggerFactory.CreateLogger<ExpressRouteCircuitDeserializer>();
                     return new ExpressRouteCircuitDeserializer(expressRouteCircuitLogger);

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
@@ -44,6 +44,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
             CreateMap<DeviceProvisioningServiceResourceV1, DeviceProvisioningServiceResourceDefinition>();
             CreateMap<CosmosDbResourceV1, CosmosDbResourceDefinition>();
             CreateMap<EventHubsResourceV1, EventHubResourceDefinition>();
+            CreateMap<EventHubClusterResourceV1, EventHubClusterResourceDefinition>();
             CreateMap<ExpressRouteCircuitResourceV1, ExpressRouteCircuitResourceDefinition>();
             CreateMap<FileStorageResourceV1, FileStorageResourceDefinition>();
             CreateMap<FrontDoorResourceV1, FrontDoorResourceDefinition>();

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Mapping/V1MappingProfile.cs
@@ -106,6 +106,7 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Mapping
                 .Include<DataShareResourceV1, DataShareResourceDefinition>()
                 .Include<DeviceProvisioningServiceResourceV1, DeviceProvisioningServiceResourceDefinition>()
                 .Include<EventHubsResourceV1, EventHubResourceDefinition>()
+                .Include<EventHubClusterResourceV1, EventHubClusterResourceDefinition>()
                 .Include<ExpressRouteCircuitResourceV1, ExpressRouteCircuitResourceDefinition>()
                 .Include<FileStorageResourceV1, FileStorageResourceDefinition>()
                 .Include<FrontDoorResourceV1, FrontDoorResourceDefinition>()

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/EventHubClusterResourceV1.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Model/ResourceTypes/EventHubClusterResourceV1.cs
@@ -1,0 +1,7 @@
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes
+{
+    public class EventHubClusterResourceV1 : AzureResourceDefinitionV1
+    {
+        public string ClusterName { get; set; }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/EventHubClusterDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/EventHubClusterDeserializer.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Logging;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+using System.Collections.Generic;
+
+namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
+{
+    public class EventHubClusterDeserializer : ResourceDeserializer<EventHubClusterResourceV1>
+    {
+        public EventHubClusterDeserializer(ILogger<EventHubClusterDeserializer> logger) : base(logger)
+        {
+        }
+
+        protected void DeserializeAdditionalProperties(EventHubClusterResourceV1 resource, IDictionary<string, object> additionalProperties)
+        {
+            if (additionalProperties.TryGetValue("clusterName", out var clusterName))
+            {
+                resource.ClusterName = clusterName.ToString();
+            }
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/EventHubClusterDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Configuration/Serialization/v1/Providers/EventHubClusterDeserializer.cs
@@ -8,14 +8,8 @@ namespace Promitor.Core.Scraping.Configuration.Serialization.v1.Providers
     {
         public EventHubClusterDeserializer(ILogger<EventHubClusterDeserializer> logger) : base(logger)
         {
-        }
-
-        protected void DeserializeAdditionalProperties(EventHubClusterResourceV1 resource, IDictionary<string, object> additionalProperties)
-        {
-            if (additionalProperties.TryGetValue("clusterName", out var clusterName))
-            {
-                resource.ClusterName = clusterName.ToString();
-            }
+            Map(resource => resource.ClusterName)
+                .IsRequired();
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
+++ b/src/Promitor.Core.Scraping/Factories/MetricScraperFactory.cs
@@ -71,6 +71,8 @@ namespace Promitor.Core.Scraping.Factories
                     return new DeviceProvisioningServiceScraper(scraperConfiguration);
                 case ResourceType.EventHubs:
                     return new EventHubsScraper(scraperConfiguration);
+                case ResourceType.EventHubCluster:
+                    return new EventHubClusterScraper(scraperConfiguration);
                 case ResourceType.ExpressRouteCircuit:
                     return new ExpressRouteCircuitScraper(scraperConfiguration);
                 case ResourceType.FileStorage:

--- a/src/Promitor.Core.Scraping/ResourceTypes/EventHubClusterScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/EventHubClusterScraper.cs
@@ -1,0 +1,28 @@
+using System;
+using Promitor.Core.Contracts;
+using Promitor.Core.Contracts.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Core.Scraping.Interfaces;
+using Promitor.Integrations.AzureMonitor;
+
+namespace Promitor.Core.Scraping.ResourceTypes
+{
+    public class EventHubClusterScraper : AzureMonitorScraper<IAzureResourceDefinition>
+    {
+        public EventHubClusterScraper(ScraperConfiguration scraperConfiguration)
+            : base(scraperConfiguration)
+        {
+        }
+
+        protected override string BuildResourceUri(string subscriptionId, ScrapeDefinition<IAzureResourceDefinition> scrapeDefinition, IAzureResourceDefinition resource)
+        {
+            var eventHubClusterResource = resource as EventHubClusterResourceDefinition;
+            if (eventHubClusterResource == null)
+            {
+                throw new ArgumentException("Invalid resource type", nameof(resource));
+            }
+
+            return $"subscriptions/{subscriptionId}/resourceGroups/{eventHubClusterResource.ResourceGroupName}/providers/Microsoft.EventHub/clusters/{eventHubClusterResource.ClusterName}";
+        }
+    }
+}

--- a/src/Promitor.Core.Scraping/ResourceTypes/EventHubClusterScraper.cs
+++ b/src/Promitor.Core.Scraping/ResourceTypes/EventHubClusterScraper.cs
@@ -9,6 +9,8 @@ namespace Promitor.Core.Scraping.ResourceTypes
 {
     public class EventHubClusterScraper : AzureMonitorScraper<IAzureResourceDefinition>
     {
+        private const string ResourceUriTemplate = "subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.EventHub/clusters/{2}";
+
         public EventHubClusterScraper(ScraperConfiguration scraperConfiguration)
             : base(scraperConfiguration)
         {
@@ -21,8 +23,7 @@ namespace Promitor.Core.Scraping.ResourceTypes
             {
                 throw new ArgumentException("Invalid resource type", nameof(resource));
             }
-
-            return $"subscriptions/{subscriptionId}/resourceGroups/{eventHubClusterResource.ResourceGroupName}/providers/Microsoft.EventHub/clusters/{eventHubClusterResource.ClusterName}";
+            return string.Format(ResourceUriTemplate, subscriptionId, scrapeDefinition.ResourceGroupName, eventHubClusterResource.ClusterName);
         }
     }
 }

--- a/src/Promitor.Core.Scraping/Serialization/v1/Mapping/V1MappingProfile.cs
+++ b/src/Promitor.Core.Scraping/Serialization/v1/Mapping/V1MappingProfile.cs
@@ -1,0 +1,1 @@
+using Promitor.Core.Scraping.ResourceTypes;

--- a/src/Promitor.Core.Scraping/Serialization/v1/Providers/EventHubClusterDeserializer.cs
+++ b/src/Promitor.Core.Scraping/Serialization/v1/Providers/EventHubClusterDeserializer.cs
@@ -1,0 +1,1 @@
+// Removed this file as it conflicts with another definition of EventHubClusterDeserializer.

--- a/src/Promitor.Tests.Unit/Scraping/ResourceTypes/EventHubClusterScraperTests.cs
+++ b/src/Promitor.Tests.Unit/Scraping/ResourceTypes/EventHubClusterScraperTests.cs
@@ -1,0 +1,80 @@
+using System;
+using Microsoft.Extensions.Logging.Abstractions;
+using Promitor.Core.Contracts.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Model;
+using Promitor.Core.Scraping.Configuration.Model.Metrics;
+using Promitor.Core.Scraping.ResourceTypes;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Scraping.ResourceTypes
+{
+    public class EventHubClusterScraperTests
+    {
+        private readonly ScrapeDefinition<IAzureResourceDefinition> _scrapeDefinition;
+        private readonly EventHubClusterScraper _scraper;
+
+        public EventHubClusterScraperTests()
+        {
+            // Arrange
+            var azureMetadata = new AzureMetadata
+            {
+                TenantId = "tenant-id",
+                SubscriptionId = "subscription-id",
+                ResourceGroupName = "resource-group-name"
+            };
+
+            var scraperConfiguration = new ScraperConfiguration(azureMetadata, NullLogger<EventHubClusterScraper>.Instance);
+            _scraper = new EventHubClusterScraper(scraperConfiguration);
+
+            _scrapeDefinition = new ScrapeDefinition<IAzureResourceDefinition>
+            {
+                ResourceGroupName = "promitor-resource-group"
+            };
+        }
+
+        [Fact]
+        public void BuildResourceUri_ValidResource_ReturnsCorrectUri()
+        {
+            // Arrange
+            var clusterName = "promitor-eventhub-cluster";
+            var resource = new EventHubClusterResourceDefinition
+            {
+                ClusterName = clusterName
+            };
+            var subscriptionId = "subscription-id";
+
+            // Act
+            var resourceUri = _scraper.GetResourceUri(subscriptionId, _scrapeDefinition, resource);
+
+            // Assert
+            var expectedUri = $"subscriptions/{subscriptionId}/resourceGroups/{_scrapeDefinition.ResourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}";
+            Assert.Equal(expectedUri, resourceUri);
+        }
+
+        [Fact]
+        public void BuildResourceUri_NullResource_ThrowsArgumentException()
+        {
+            // Arrange
+            EventHubClusterResourceDefinition resource = null;
+            var subscriptionId = "subscription-id";
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => _scraper.GetResourceUri(subscriptionId, _scrapeDefinition, resource));
+        }
+
+        [Fact]
+        public void BuildResourceUri_WrongResourceType_ThrowsArgumentException()
+        {
+            // Arrange
+            var resource = new MockResourceDefinition();
+            var subscriptionId = "subscription-id";
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => _scraper.GetResourceUri(subscriptionId, _scrapeDefinition, resource));
+        }
+
+        private class MockResourceDefinition : IAzureResourceDefinition
+        {
+        }
+    }
+}

--- a/src/Promitor.Tests.Unit/Serialization/v1/Providers/EventHubClusterDeserializerTests.cs
+++ b/src/Promitor.Tests.Unit/Serialization/v1/Providers/EventHubClusterDeserializerTests.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel;
+using Promitor.Core.Scraping.Configuration.Serialization;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Model.ResourceTypes;
+using Promitor.Core.Scraping.Configuration.Serialization.v1.Providers;
+using Xunit;
+
+namespace Promitor.Tests.Unit.Serialization.v1.Providers
+{
+    [Category("Unit")]
+    public class EventHubClusterDeserializerTests : ResourceDeserializerTest<EventHubClusterDeserializer>
+    {
+        private readonly EventHubClusterDeserializer _deserializer;
+
+        public EventHubClusterDeserializerTests()
+        {
+            _deserializer = new EventHubClusterDeserializer(Logger);
+        }
+
+        [Fact]
+        public void Deserialize_ClusterNameSupplied_SetsClusterName()
+        {
+            const string clusterName = "promitor-eventhub-cluster";
+            YamlAssert.PropertySet<EventHubClusterResourceV1, AzureResourceDefinitionV1, string>(
+                _deserializer,
+                $"clusterName: {clusterName}",
+                clusterName,
+                r => r.ClusterName);
+        }
+
+        [Fact]
+        public void Deserialize_ClusterNameNotSupplied_Null()
+        {
+            YamlAssert.PropertyNull<EventHubClusterResourceV1, AzureResourceDefinitionV1>(
+                _deserializer,
+                "resourceGroupName: promitor-group",
+                r => r.ClusterName);
+        }
+
+        [Fact]
+        public void Deserialize_ClusterNameNotSupplied_ReportsError()
+        {
+            // Arrange
+            var node = YamlUtils.CreateYamlNode("resourceGroupName: promitor-resource-group");
+
+            // Act / Assert
+            YamlAssert.ReportsErrorForProperty(
+                _deserializer,
+                node,
+                "clusterName");
+        }
+
+        protected override IDeserializer<AzureResourceDefinitionV1> CreateDeserializer()
+        {
+            return new EventHubClusterDeserializer(Logger);
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- For new scrapers, make sure to follow https://github.com/tomkerkhove/promitor/blob/master/adding-a-new-scraper.md

When implementing a new scraper; these tasks are completed:
- [ ] Implement configuration
- [ ] Implement validation
- [ ] Implement scraping
- [ ] Implement resource discovery
- [ ] Provide unit tests
- [ ] Test end-to-end
- [ ] Document scraper (see https://github.com/promitor/docs/blob/main/CONTRIBUTING.md#documenting-a-new-scraper)
- [ ] Add entry to changelog (see https://github.com/tomkerkhove/promitor/blob/master/CONTRIBUTING.md#changelog)

**Metrics output:**
```
# HELP azure_network_gateway_count_ingress_package_drop Total count of ingress package drops on an Azure network gateway
# TYPE azure_network_gateway_count_ingress_package_drop gauge
azure_network_gateway_count_ingress_package_drop{resource_group="RG",subscription_id="SUB",resource_uri="subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Network/virtualNetworkGateways/Azure-Tele-Gateway",instance_name="Azure-Tele-Gateway"} 19.4 1599219001456
# HELP promitor_ratelimit_arm Indication how many calls are still available before Azure Resource Manager is going to throttle us.
# TYPE promitor_ratelimit_arm gauge
promitor_ratelimit_arm{tenant_id="T",subscription_id="SUB",app_id="APP"} 11996 1599219001431
```

**Discovery output:**
```json
[{"$type":"Promitor.Core.Contracts.ResourceTypes.NetworkGatewayResourceDefinition, Promitor.Core.Contracts","NetworkGatewayName":"Azure-Tele-Gateway","ResourceType":"NetworkGateway","SubscriptionId":"SUB","ResourceGroupName":"RG","ResourceName":"Azure-Tele-Gateway","UniqueName":"Azure-Tele-Gateway"}]
```

 -->

Fixes #

<!-- markdownlint-enable -->
